### PR TITLE
Allow for "invite" to be aliased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Changed
+
+- Unique Invites `create` defaults to 1 invite
+- Core `invite` command renamed to `botinviteurl`
+
 ## [1.5.4] - 2025-07-06
 
 ### Fixed

--- a/discord/Containerfile
+++ b/discord/Containerfile
@@ -21,6 +21,11 @@ RUN sed -i -e \
   's/await send_to_owners_with_prefix_replaced(bot, outdated_red_message)/pass/' \
   "$(pip show Red-DiscordBot | grep "Location:" | awk '{print $2}')/redbot/core/_events.py"
 
+# rename invite command so we can alias invite to other things
+RUN sed -i -e \
+  's/async def invite\b/async def botinviteurl/' \
+  "$(pip show Red-DiscordBot | grep "Location:" | awk '{print $2}')/redbot/core/core_commands.py"
+
 COPY config/config.json /root/.config/Red-DiscordBot/config.json
 COPY local-share/data/ibis /root/.local/share/Red-DiscordBot/data/ibis
 COPY submodules/Trusty-cogs/extendedmodlog/ /root/.local/share/Red-DiscordBot/data/ibis/cogs/CogManager/cogs/extendedmodlog/

--- a/discord/cogs/uniqueinvites/uniqueinvites.py
+++ b/discord/cogs/uniqueinvites/uniqueinvites.py
@@ -145,7 +145,7 @@ class UniqueInvites(commands.Cog):
         self,
         ctx: commands.Context,
         channel: Union[discord.TextChannel, discord.ForumChannel],
-        amount: int,
+        amount: int = 1,
     ):
         """Create unique, non-expiring, single use invites for the specified channel"""
 


### PR DESCRIPTION
I wanted to be able to alias `invite` to `uniqueinvites create #some-channel`.