### PR TITLE
Improve handling of long running interactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Improved handling of long running interactions.
+
 ## [2.3.1] - 2026-06-08
 
 ### Fixed

--- a/discord/cogs/namechanger/namechanger.py
+++ b/discord/cogs/namechanger/namechanger.py
@@ -220,6 +220,8 @@ class NameChangerModal(discord.ui.Modal, title=""):
 
     # pylint: disable-next=arguments-differ
     async def on_submit(self, interaction: discord.Interaction):
+        await interaction.response.defer(ephemeral=True, thinking=True)
+
         data = self.parse_data()
         split_regex = re.compile(r"(\[|\(|\{)")
 
@@ -233,7 +235,7 @@ class NameChangerModal(discord.ui.Modal, title=""):
         results = validator.validate(data.new_handle)
 
         if any(result.error for result in results):
-            await interaction.response.send_message(
+            await interaction.followup.send(
                 "\n".join(
                     [
                         f"Your requested new handle, `{data.new_handle}`, has failed validation.",
@@ -248,19 +250,25 @@ class NameChangerModal(discord.ui.Modal, title=""):
 
         thread = await self.create_post(interaction, data, results)
 
-        await interaction.response.send_message(
+        await interaction.followup.send(
             f"Your handle change request was received. [Click here to view it]({thread.jump_url}).",
             ephemeral=True,
         )
 
     # pylint: disable-next=arguments-differ
     async def on_error(self, interaction: discord.Interaction, error: Exception):
-        await interaction.response.send_message(
-            "Something went wrong and your submission was not received. Please try again.",
-            ephemeral=True,
-        )
-
         _log.exception("Something went wrong handling a submission", exc_info=error)
+
+        if interaction.response.is_done():
+            await interaction.followup.send(
+                "Something went wrong and your submission was not received. Please try again.",
+                ephemeral=True,
+            )
+        else:
+            await interaction.response.send_message(
+                "Something went wrong and your submission was not received. Please try again.",
+                ephemeral=True,
+            )
 
 
 class NameChanger(commands.Cog):

--- a/discord/cogs/sostickets/modals.py
+++ b/discord/cogs/sostickets/modals.py
@@ -113,24 +113,31 @@ class SosTicketsModal(discord.ui.Modal, title=""):
 
     # pylint: disable-next=arguments-differ
     async def on_submit(self, interaction: discord.Interaction):
+        await interaction.response.defer(ephemeral=True, thinking=True)
+
         message = await self.callback(
             "\n".join(self.format_response(interaction)),
             await self.files(),
         )
-        await interaction.response.send_message(
+        await interaction.followup.send(
             f"Your submission was received. [Click here to view it]({message.jump_url}).",
             ephemeral=True,
         )
 
     # pylint: disable-next=arguments-differ
     async def on_error(self, interaction: discord.Interaction, error: Exception):
-        await interaction.response.send_message(
-            "Something went wrong and your submission was not received. Please try again.",
-            ephemeral=True,
-        )
-
-        # Make sure we know what the error actually is
         _log.exception("Something went wrong handling a submission", exc_info=error)
+
+        if interaction.response.is_done():
+            await interaction.followup.send(
+                "Something went wrong and your submission was not received. Please try again.",
+                ephemeral=True,
+            )
+        else:
+            await interaction.response.send_message(
+                "Something went wrong and your submission was not received. Please try again.",
+                ephemeral=True,
+            )
 
     async def files(self) -> list[discord.File]:
         files: list[discord.File] = []


### PR DESCRIPTION
Discord requires interactions be responded to within 3 seconds, or they're considered invalid.

In the Name Changer cog, in large enough servers, a response might take longer than 3 seconds to form.

To be safe, I've gone with just always deferring the responses when a message is involved.

Note: this isn't required in the modal cases as there is no message being sent, but rather a modal being shown.