### PR TITLE
Fix problems with Shopify cog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Changed TimeZone cog commands to use `get`/`set`/`clear` sub-commands.
+- Shopify cog now logs in some cases when webhook was received but nothing happened.
+
+### Fixed
+
+- Shopify container calling outdated RPC method name.
+- `[@] shopify channel` when no channel is set no longer errors.
 
 ## [2.4.0] - 2026-06-21
 

--- a/discord/cogs/shopify/shopify.py
+++ b/discord/cogs/shopify/shopify.py
@@ -1,10 +1,13 @@
 from datetime import datetime
 from typing import Union, Literal
+import logging
 import asyncio
 import re
 from redbot.core import commands, Config
 import discord
 import ibis
+
+_log = logging.getLogger(__name__)
 
 
 # pylint: disable-next=too-many-instance-attributes
@@ -208,10 +211,14 @@ class ShopifyCog(commands.Cog):
     ):
         """Globally get or set Shopify output channel."""
         if not channel:
-            await ibis.reply.success(
-                ctx,
-                f"Shopify channel currently set to {(await self.get_channel()).mention}",
-            )
+            channel = await self.get_channel()
+            if channel:
+                await ibis.reply.success(
+                    ctx,
+                    f"Shopify channel currently set to {channel.mention}",
+                )
+            else:
+                await ibis.reply.success(ctx, "Shopify channel is not set")
         else:
             await self.set_channel(channel)
             await self.set_staff([])
@@ -359,6 +366,10 @@ class ShopifyCog(commands.Cog):
 
     async def webhook(self, topic: str, body) -> bool:
         if not await self.config.shop_channel():
+            _log.info(
+                "Received %s request, but no shop channel is configured, ignoring.",
+                topic,
+            )
             return True
 
         order = ShopifyOrder(self.bot, body)
@@ -372,6 +383,8 @@ class ShopifyCog(commands.Cog):
                 await self.orders_fulfilled(order)
             case "ORDERS_CANCELLED":
                 await self.orders_cancelled(order)
+            case _:
+                _log.error("Unknown topic %s supplied.", topic)
 
         return True
 

--- a/shopify/src/index.ts
+++ b/shopify/src/index.ts
@@ -33,7 +33,7 @@ async function callBot(topic: string, shop: string, body: string) {
   return new Promise((resolve, reject) => {
     const payload = JSON.stringify({
       jsonrpc: "2.0",
-      method: "SHOPIFY__WEBHOOK",
+      method: "SHOPIFYCOG__WEBHOOK",
       params: [topic, bodyObj],
       id: crypto.randomUUID()
     });
@@ -79,9 +79,13 @@ const defaultHandler: WebhookHandler = {
   deliveryMethod: DeliveryMethod.Http,
   callbackUrl: shopify.config.webhooks.path,
   async callback(topic, shop, body) {
-    callBot(topic, shop, body).catch((error) => {
-      console.error("[ibis-shopify/ERROR]", error.stack ?? error);
-    });
+    callBot(topic, shop, body)
+      .then((result) => {
+        console.log("[ibis-shopify/INFO]", topic, result);
+      })
+      .catch((error) => {
+        console.error("[ibis-shopify/ERROR]", error.stack ?? error);
+      });
   }
 };
 


### PR DESCRIPTION
- Shopify cog now logs in some cases when webhook was received but nothing happened.
- Shopify container calling outdated RPC method name.
- `[@] shopify channel` when no channel is set no longer errors.