### PR TITLE
Allow SOS Tickets buttons to be ordered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- SOS Tickets buttons allow for ordering.
+
 ## [2.5.0] - 2026-08-01
 
 ### Changed

--- a/discord/cogs/sostickets/schema.py
+++ b/discord/cogs/sostickets/schema.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass, field
 from typing import Optional, Any
 from enum import Enum
 from pathlib import Path
+import math
 import yaml
 import jsonschema
 import discord
@@ -85,6 +86,7 @@ class Prompt:
     prompt_id: str
     full_title: str
     title: str
+    order: float = math.inf
     emoji: Optional[str] = None
     accent: Optional[str] = None
     style: discord.ButtonStyle = discord.ButtonStyle.primary
@@ -116,6 +118,7 @@ class Prompt:
             prompt_id=prompt_id,
             full_title=full_title,
             title=data["title"],
+            order=data.get("order", math.inf),
             emoji=data.get("emoji"),
             items=items,
             assignees=assignees,
@@ -132,7 +135,10 @@ class PromptsConfig:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "PromptsConfig":
         PromptsConfig.validate(data)
-        prompts = [Prompt.from_dict(id, data) for id, data in data["prompts"].items()]
+        prompts = sorted(
+            [Prompt.from_dict(id, data) for id, data in data["prompts"].items()],
+            key=lambda prompt: prompt.order,
+        )
         return cls(prompts=prompts)
 
     @classmethod

--- a/discord/cogs/sostickets/schema.yaml
+++ b/discord/cogs/sostickets/schema.yaml
@@ -19,6 +19,11 @@ properties:
           type: string
           description: Title of the prompt.
 
+        order:
+          type: number
+          minimum: 1
+          description: Optional. Order in which prompt is displayed, ascending. Defaults to being displayed at the end.
+
         emoji:
           type: string
           description: Optional. Emoji prefix for the prompt.


### PR DESCRIPTION
Prompts keep ending up in alphabetical order - not what I want.